### PR TITLE
Fixing typos in Griptape Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Docs](https://readthedocs.org/projects/griptape/badge/)](https://griptape.readthedocs.io)
 
-Docs for the [Griptape](https://github.com/griptape-ai/griptape).
+Docs for [Griptape](https://github.com/griptape-ai/griptape).

--- a/docs/griptape-framework/index.md
+++ b/docs/griptape-framework/index.md
@@ -26,7 +26,7 @@ If you're using PyCharm, open the directory, and you'll be prompted to setup the
 
 ![Poetry Setup](../assets/img/tools/poetry_setup.png)
 
-Add `griptape = "*"` to your **pyproject.yml** file. You should notice PyCharm asking if it should run `poetry update`. The answer is yes:
+Add `griptape = "*"` to your **pyproject.toml** file. You should notice PyCharm asking if it should run `poetry update`. The answer is yes:
 
 ![TOML](../assets/img/tools/toml.png)
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--32.org.readthedocs.build/en/32/

<!-- readthedocs-preview griptape end -->