### PR TITLE
Update rest api docs to use tool memory, improve prompts

### DIFF
--- a/docs/griptape-tools/official-tools/rest-api-client.md
+++ b/docs/griptape-tools/official-tools/rest-api-client.md
@@ -24,11 +24,19 @@ from griptape.memory.structure import ConversationMemory
 from griptape.structures import Pipeline
 from griptape.tasks import ToolkitTask
 from griptape.tools import RestApiClient
+from griptape.memory.tool import TextToolMemory
 
+text_memory = TextToolMemory()
 posts_client = RestApiClient(
     base_url="https://jsonplaceholder.typicode.com",
     path="posts",
     description="Allows for creating, updating, deleting, patching, and getting posts.",
+    output_memory={
+        "get": [text_memory]
+    },
+    input_memory={
+        "get": [text_memory]
+    },
     request_body_schema=dumps(
         {
             "$schema": "https://json-schema.org/draft/2019-09/schema",
@@ -134,11 +142,11 @@ pipeline = Pipeline(
 
 pipeline.add_tasks(
     ToolkitTask(
-        "Get the title of post 1.",
+        "Output the title of post 1.",
         tools=[posts_client],
     ),
     ToolkitTask(
-        "Get the titles of all posts.",
+        "Output the titles of all posts.",
         tools=[posts_client],
     ),
     ToolkitTask(
@@ -158,7 +166,7 @@ pipeline.add_tasks(
         tools=[posts_client],
     ),
     ToolkitTask(
-        "Get the body of all the comments for post 1.",
+        "Output the body of all the comments for post 1.",
         tools=[posts_client],
     ),
 )


### PR DESCRIPTION
The output of the get posts example is large enough to require using tool memory.

<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--35.org.readthedocs.build/en/35/

<!-- readthedocs-preview griptape end -->