### PR TITLE
FIX 404 ERROR FOR Text Generation Web UI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,4 +113,4 @@ nav:
       - Query a Webpage: "examples/query-webpage.md"
     - Misc:
         - Count Tokens: "examples/count-tokens.md"
-        - Text Generation Web UI: "examples/text-generation-web-ui.md"
+        - Text Generation Web UI: "examples/talk-to-text-gen.md"


### PR DESCRIPTION
## What is the problem we're trying to solve?
![image](https://github.com/griptape-ai/griptape-docs/assets/7805464/870b70f1-9af5-4a64-8ae8-a62039996034)

## Cause
In a recent commit examples/text-generation-web-ui.md was renamed to talk-to-text-gen.md but this change wasn't reflected in mkdocs.yml.

## Solution
Renaming the file corrected the problem, I built the docs locally and validated the change worked correctly:
![image](https://github.com/griptape-ai/griptape-docs/assets/7805464/aa1866b3-ca93-4634-9b48-6055ca777055)
