### PR TITLE
fixed handler function to use event instead of e

### DIFF
--- a/docs/griptape-framework/structures/events.md
+++ b/docs/griptape-framework/structures/events.md
@@ -14,7 +14,7 @@ from griptape.events import (
     FinishPromptEvent,
 )
 
-def handler(e: BaseEvent):
+def handler(event: BaseEvent):
     print(event)
 
 agent = Agent(


### PR DESCRIPTION
Fixed a bug in the handler function in events documentation where it called `e` instead of `event`.



<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--46.org.readthedocs.build/en/46/

<!-- readthedocs-preview griptape end -->