### PR TITLE
Add missing imports

### DIFF
--- a/docs/griptape-framework/structures/prompt-drivers.md
+++ b/docs/griptape-framework/structures/prompt-drivers.md
@@ -5,6 +5,9 @@ Prompt drivers are used by Griptape structures to make calls to the underlying f
 You can instantiate drivers and pass them to structures:
 
 ```python
+from griptape.structures import Pipeline
+from griptape.drivers import OpenAiChatPromptDriver
+
 Pipeline(
     prompt_driver=OpenAiChatPromptDriver(
         temperature=0.3
@@ -15,6 +18,9 @@ Pipeline(
 Or use them independently:
 
 ```python
+from griptape.utils import PromptStack
+from griptape.drivers import OpenAiChatPromptDriver
+
 stack = PromptStack()
 
 stack.add_user_input("What's the word, bird?")


### PR DESCRIPTION
Not sure if these are really "missing" imports since they're pretty small code snippets. Maybe they're not intended to be copy-pasted and run from the docs. In any case, I don't think it hurts to have the imports.

<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--52.org.readthedocs.build/en/52/

<!-- readthedocs-preview griptape end -->