### PR TITLE
Remove extra newline below imports

### DIFF
--- a/docs/griptape-framework/data/embeddings.md
+++ b/docs/griptape-framework/data/embeddings.md
@@ -31,7 +31,6 @@ Here is how you can use it:
 ```python
 from griptape.drivers import OpenAiEmbeddingDriver
 
-
 OpenAiEmbeddingDriver().embed_string("Hello Griptape!")
 ```
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview griptape end -->