### PR TITLE
Remove REPL snippets

### DIFF
--- a/docs/griptape-framework/data/chunkers.md
+++ b/docs/griptape-framework/data/chunkers.md
@@ -11,14 +11,12 @@ Different types of chunkers provide lists of separators for specific text shapes
 Here is how to use a chunker:
 
 ```python
->>> from griptape.chunkers import TextChunker
->>> from griptape.tokenizers import TiktokenTokenizer
->>> TextChunker(
-...     # set an optional custom tokenizer
-...     tokenizer=TiktokenTokenizer(),
-...     # optionally modify default number of tokens
-...     max_tokens=100
-... ).chunk("long text")
-[TextArtifact(id='...', name='...', type='TextArtifact', value='long text', _TextArtifact__embedding=[])]
-
+from griptape.chunkers import TextChunker
+from griptape.tokenizers import TiktokenTokenizer
+TextChunker(
+     # set an optional custom tokenizer
+     tokenizer=TiktokenTokenizer(),
+     # optionally modify default number of tokens
+     max_tokens=100
+).chunk("long text")
 ```

--- a/docs/griptape-framework/data/embedding-drivers.md
+++ b/docs/griptape-framework/data/embedding-drivers.md
@@ -16,10 +16,10 @@ The [OpenAiEmbeddingDriver](../../reference/griptape/drivers/embedding/openai_em
 Here is how you can use it:
 
 ```python
->>> from griptape.drivers import OpenAiEmbeddingDriver
+from griptape.drivers import OpenAiEmbeddingDriver
 
->>> OpenAiEmbeddingDriver().embed_string("Hello Griptape!")
-[0.0018212645081803203, 0.006074181292206049, -0.005777235608547926, ...]
+OpenAiEmbeddingDriver().embed_string("Hello Griptape!")
+
 
 ```
 

--- a/docs/griptape-framework/data/loaders.md
+++ b/docs/griptape-framework/data/loaders.md
@@ -9,21 +9,16 @@ multiple documents with ['load_collection()](../../reference/griptape/loaders/ba
 Inherits from the [TextLoader](../../reference/griptape/loaders/text_loader.md) and can be used to load PDFs from a path or from an IO stream:
 
 ```python
->>> from griptape.loaders import PdfLoader
->>> import urllib.request
+from griptape.loaders import PdfLoader
+import urllib.request
 
->>> urllib.request.urlretrieve("https://arxiv.org/pdf/1706.03762.pdf", "attention.pdf")
-('attention.pdf', <http.client.HTTPMessage object at ...>)
+urllib.request.urlretrieve("https://arxiv.org/pdf/1706.03762.pdf", "attention.pdf")
 
->>> PdfLoader().load("attention.pdf")
-[TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])]
+PdfLoader().load("attention.pdf")
 
->>> urllib.request.urlretrieve("https://arxiv.org/pdf/1706.03762.pdf", "CoT.pdf")
-('CoT.pdf', <http.client.HTTPMessage object at ...>)
+urllib.request.urlretrieve("https://arxiv.org/pdf/1706.03762.pdf", "CoT.pdf")
 
->>> PdfLoader().load_collection(["attention.pdf", "CoT.pdf"])
-{'...': [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])], '...': [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])]}
-
+PdfLoader().load_collection(["attention.pdf", "CoT.pdf"])
 ```
 
 ## SqlLoader
@@ -31,23 +26,20 @@ Inherits from the [TextLoader](../../reference/griptape/loaders/text_loader.md) 
 Can be used to load data from a SQL database into [CsvRowArtifact](../../reference/griptape/artifacts/csv_row_artifact.md)s:
 
 ```python
->>> from griptape.loaders import SqlLoader
->>> from griptape.drivers import SqlDriver
+from griptape.loaders import SqlLoader
+from griptape.drivers import SqlDriver
 
->>> SqlLoader(
-...     sql_driver = SqlDriver(
-...        engine_url="sqlite:///:memory:"
-...     )
-... ).load("SELECT 'foo', 'bar'")
-[CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={"'foo'": 'foo', "'bar'": 'bar'}, delimiter=',')]
+SqlLoader(
+    sql_driver = SqlDriver(
+        engine_url="sqlite:///:memory:"
+    )
+).load("SELECT 'foo', 'bar'")
 
->>> SqlLoader(
-...    sql_driver = SqlDriver(
-...        engine_url="sqlite:///:memory:"
-...    )
-... ).load_collection(["SELECT 'foo', 'bar';", "SELECT 'fizz', 'buzz';"])
-{'...': [CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={"'foo'": 'foo', "'bar'": 'bar'}, delimiter=',')], '...': [CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={"'fizz'": 'fizz', "'buzz'": 'buzz'}, delimiter=',')]}
-
+SqlLoader(
+    sql_driver = SqlDriver(
+        engine_url="sqlite:///:memory:"
+    )
+).load_collection(["SELECT 'foo', 'bar';", "SELECT 'fizz', 'buzz';"])
 ```
 
 ## CsvLoader
@@ -55,25 +47,20 @@ Can be used to load data from a SQL database into [CsvRowArtifact](../../referen
 Can be used to load CSV files into [CsvRowArtifact](../../reference/griptape/artifacts/csv_row_artifact.md)s:
 
 ```python
->>> import urllib
->>> from griptape.loaders import CsvLoader
+import urllib
+from griptape.loaders import CsvLoader
 
->>> urllib.request.urlretrieve("https://people.sc.fsu.edu/~jburkardt/data/csv/cities.csv", "cities.csv")
-('cities.csv', <http.client.HTTPMessage object at ...>)
+urllib.request.urlretrieve("https://people.sc.fsu.edu/~jburkardt/data/csv/cities.csv", "cities.csv")
 
->>> CsvLoader().load(
-...    "cities.csv"
-... )
-[CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={...}, delimiter=','), ...]
+CsvLoader().load(
+    "cities.csv"
+)
 
->>> urllib.request.urlretrieve("https://people.sc.fsu.edu/~jburkardt/data/csv/addresses.csv", "addresses.csv")
-('addresses.csv', <http.client.HTTPMessage object at ...>)
+urllib.request.urlretrieve("https://people.sc.fsu.edu/~jburkardt/data/csv/addresses.csv", "addresses.csv")
 
->>> CsvLoader().load_collection(
-...     ["cities.csv", "addresses.csv"]
-... )
-{'...': [CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={...}, delimiter=','), ...], '...': [CsvRowArtifact(id='...', name='...', type='CsvRowArtifact', _TextArtifact__embedding=[], value={...}, delimiter=','), ...]}
- 
+CsvLoader().load_collection(
+    ["cities.csv", "addresses.csv"]
+)
 ```
 
 ## TextLoader
@@ -81,28 +68,24 @@ Can be used to load CSV files into [CsvRowArtifact](../../reference/griptape/art
 Used to load arbitrary text and text files:
 
 ```python
->>> from pathlib import Path
->>> import urllib
->>> from griptape.loaders import TextLoader
+from pathlib import Path
+import urllib
+from griptape.loaders import TextLoader
 
->>> TextLoader().load(
-...    "my text"
-... )
-[TextArtifact(id='...', name='...', type='TextArtifact', value='my text', _TextArtifact__embedding=[])]
+TextLoader().load(
+    "my text"
+)
 
->>> urllib.request.urlretrieve("https://example-files.online-convert.com/document/txt/example.txt", "example.txt")
-('example.txt', <http.client.HTTPMessage object at ...>)
+urllib.request.urlretrieve("https://example-files.online-convert.com/document/txt/example.txt", "example.txt")
 
->>> TextLoader().load(
-...    Path("example.txt")
-... )
+TextLoader().load(
+    Path("example.txt")
+)
 [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])]
 
->>> TextLoader().load_collection(
-...     ["my text", "my other text", Path("example.txt")]
-... )
-{'...': [TextArtifact(id='...', name='...', type='TextArtifact', value='my text', _TextArtifact__embedding=[])], '...': [TextArtifact(id='...', name='...', type='TextArtifact', value='my other text', _TextArtifact__embedding=[])], '...': [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])]}
-    
+TextLoader().load_collection(
+    ["my text", "my other text", Path("example.txt")]
+)
 ```
 
 You can set a custom [tokenizer](../../reference/griptape/loaders/text_loader.md#griptape.loaders.text_loader.TextLoader.tokenizer.md), [max_tokens](../../reference/griptape/loaders/text_loader.md#griptape.loaders.text_loader.TextLoader.max_tokens.md) parameter, and [chunker](../../reference/griptape/loaders/text_loader.md#griptape.loaders.text_loader.TextLoader.chunker.md).
@@ -112,16 +95,14 @@ You can set a custom [tokenizer](../../reference/griptape/loaders/text_loader.md
 Inherits from the [TextLoader](../../reference/griptape/loaders/text_loader.md) and can be used to load web pages:
 
 ```python
->>> from griptape.loaders import WebLoader
+from griptape.loaders import WebLoader
 
->>> WebLoader().load(
-...     "https://www.griptape.ai"
-... )
+WebLoader().load(
+    "https://www.griptape.ai"
+)
 [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])]
 
->>> WebLoader().load_collection(
-...    ["https://www.griptape.ai", "https://docs.griptape.ai"]
-... )
-{'...': [TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])], '...': [TextArtifact(id='...', name='...', type='TextArtifact', value="...", _TextArtifact__embedding=[])]}
-
+WebLoader().load_collection(
+    ["https://www.griptape.ai", "https://docs.griptape.ai"]
+)
 ```

--- a/docs/griptape-framework/data/query-engines.md
+++ b/docs/griptape-framework/data/query-engines.md
@@ -10,19 +10,17 @@ Use the [upsert_text_artifact](../../reference/griptape/engines/query/vector_que
 Use the [VectorQueryEngine](../../reference/griptape/engines/query/vector_query_engine.md#griptape.engines.query.vector_query_engine.VectorQueryEngine.query.md) method to query the vector storage.
 
 ```python
->>> from griptape.engines import VectorQueryEngine
->>> from griptape.loaders import WebLoader
+from griptape.engines import VectorQueryEngine
+from griptape.loaders import WebLoader
 
->>> engine = VectorQueryEngine()
+engine = VectorQueryEngine()
 
->>> engine.upsert_text_artifacts(
-...    WebLoader().load("https://www.griptape.ai"), namespace="griptape"
-... )
+engine.upsert_text_artifacts(
+    WebLoader().load("https://www.griptape.ai"), namespace="griptape"
+)
 
->>> engine.query(
-...    "what is griptape?",
-...    namespace="griptape"
-... )
-TextArtifact(id='...', name='...', type='TextArtifact', value='...', _TextArtifact__embedding=[])
-
+engine.query(
+    "what is griptape?",
+    namespace="griptape"
+)
 ```

--- a/docs/griptape-framework/data/summary-engines.md
+++ b/docs/griptape-framework/data/summary-engines.md
@@ -9,21 +9,19 @@ Used to summarize texts with LLMs. You can set a custom [prompt_driver](../../re
 Use the [summarize_artifacts](../../reference/griptape/engines/summary/prompt_summary_engine.md#griptape.engines.summary.prompt_summary_engine.PromptSummaryEngine.summarize_artifacts) method to summarize a list of artifacts or [summarize_text](../../reference/griptape/engines/summary/prompt_summary_engine.md#griptape.engines.summary.prompt_summary_engine.PromptSummaryEngine.summarize_text) to summarize an arbitrary string.
 
 ```python
->>> import io
->>> import requests
->>> from griptape.engines import PromptSummaryEngine
->>> from griptape.loaders import PdfLoader
+import io
+import requests
+from griptape.engines import PromptSummaryEngine
+from griptape.loaders import PdfLoader
 
->>> response = requests.get("https://arxiv.org/pdf/1706.03762.pdf")
->>> engine = PromptSummaryEngine()
+response = requests.get("https://arxiv.org/pdf/1706.03762.pdf")
+engine = PromptSummaryEngine()
 
->>> artifacts = PdfLoader().load(
-...     io.BytesIO(response.content)
-... )
+artifacts = PdfLoader().load(
+    io.BytesIO(response.content)
+)
 
->>> text = "\n\n".join([a.value for a in artifacts])
+text = "\n\n".join([a.value for a in artifacts])
 
->>> engine.summarize_text(text)
-'...'
-
+engine.summarize_text(text)
 ```

--- a/tests/integration/test_repl_snippets.py
+++ b/tests/integration/test_repl_snippets.py
@@ -1,8 +1,0 @@
-import doctest
-import pathlib
-import pytest
-
-# Note the use of `str`, makes for pretty output
-@pytest.mark.parametrize('fpath', pathlib.Path("docs").glob("**/*.md"), ids=str)
-def test_code_snippets(fpath):
-    doctest.testfile('../../' + str(fpath), optionflags=doctest.ELLIPSIS)


### PR DESCRIPTION
I'm removing the REPL snippets because they:
1. Broke the integration tests because the code snippets were technically no longer valid python (`>>>` characters).
2. Made copying the examples cumbersome because the copy button included `>>>` characters.

We could add print back to these examples, but many of them output _a lot_ of text, so printing to stdout isn't really that useful IMO.

<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--83.org.readthedocs.build/en/83/

<!-- readthedocs-preview griptape end -->