### PR TITLE
Contributing page had a typo 

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,7 +17,7 @@ From inside the directory run:
 
 To run `griptape-docs` locally run: 
 
-```peotry run mkdocs serve```
+```poetry run mkdocs serve```
 
 You should see something similar to the following: 
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--131.org.readthedocs.build/

<!-- readthedocs-preview griptape end -->