### PR TITLE
Update contributing guidelines to match main repo

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,12 +1,20 @@
 # Contributing
 
-We appreciate contributions and help maintaining this repository.
+Thank you for considering contributing to Griptape documentation! Before you start, please read the following guidelines.
 
-## Report and Issue
-The easiest way to contribute to our docs is through our public [issue tracker](https://github.com/griptape-ai/griptape-docs/issues). Feel free to submit bugs, request features or changes, or contribute to the project directly. 
+## Submitting Issues
 
-## Pull Requests
+If you have identified a documentation issue, want to propose new documentation, or have a question, please submit an issue through our public [issue tracker](https://github.com/griptape-ai/griptape-docs/issues). Before submitting a new issue, please check the existing issues to ensure it hasn't been reported or discussed before.
 
+## Submitting Pull Requests
+
+We welcome and encourage pull requests. To streamline the process, please follow these guidelines:
+
+1. **Existing Issues:** Please submit pull requests only for existing issues. If you want to add new documentation or fix a documentation issue that hasn't been addressed yet, please first submit an issue. This allows the Griptape team to internally process the request and provide a public response.
+
+2. **Branch:** Submit all pull requests to the `dev` branch. This helps us manage changes and integrate them smoothly.
+
+## Getting Started
 Griptape docs are built using [MkDocs](https://squidfunk.github.io/mkdocs-material/getting-started/). Dependencies are managed using [Poetry](https://python-poetry.org/).
 
 To directly contribute to Griptape documentation, first fork the [griptape-docs](https://github.com/griptape-ai/griptape-docs) repository to your GitHub account. Then clone your repository to your local machine.
@@ -30,6 +38,8 @@ INFO     -  [09:28:33] Serving on http://127.0.0.1:8000/
 INFO     -  [09:28:37] Browser connected: http://127.0.0.1:8000/
 ```
 
+### Reference Docs
+
 You may see many `WARNING` messages in the console output. This is because the [reference docs](./reference/griptape/index.md) are not built.
 Fixing this is not necessary to contribute to the documentation, but it helps to reduce noise in the console output.
 
@@ -42,10 +52,3 @@ Then, create a symlink called `griptape` in the `griptape-docs` repository:
 `ln -s ~/some/other/directory/griptape griptape`
 
 The `WARNING` messages should now be resolved. 
-
-
-Follow the typical PR process to contribute changes. 
-
-* Create a feature branch.
-* Commit changes.
-* Submit a PR.


### PR DESCRIPTION
Relates to https://github.com/griptape-ai/griptape/pull/394v

<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--133.org.readthedocs.build/

<!-- readthedocs-preview griptape end -->