### PR TITLE
docs: adding missing model to tokenizer

### DIFF
--- a/docs/griptape-framework/data/chunkers.md
+++ b/docs/griptape-framework/data/chunkers.md
@@ -15,7 +15,7 @@ from griptape.chunkers import TextChunker
 from griptape.tokenizers import OpenAiTokenizer
 TextChunker(
      # set an optional custom tokenizer
-     tokenizer=OpenAiTokenizer(),
+     tokenizer=OpenAiTokenizer(model=OpenAiTokenizer.DEFAULT_OPENAI_GPT_4_MODEL),
      # optionally modify default number of tokens
      max_tokens=100
 ).chunk("long text")


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--134.org.readthedocs.build/

<!-- readthedocs-preview griptape end -->