### PR TITLE
Remove warning about workflows missing conversation memory

### DIFF
--- a/docs/griptape-framework/structures/conversation-memory.md
+++ b/docs/griptape-framework/structures/conversation-memory.md
@@ -93,9 +93,6 @@ agent.run("What is my favorite food?")
 
 ### Workflows
 
-!!! Warning
-    [Workflows](./workflows.md) do not currently support Conversation Memory.
-
 ## Types of Memory
 
 Griptape provides several types of Conversation Memory to fit various use-cases.


### PR DESCRIPTION
Docs for https://github.com/griptape-ai/griptape/pull/428
<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--144.org.readthedocs.build/

<!-- readthedocs-preview griptape end -->