### PR TITLE
Fix missing references to tool memory

### DIFF
--- a/docs/griptape-framework/data/artifacts.md
+++ b/docs/griptape-framework/data/artifacts.md
@@ -1,6 +1,6 @@
 ## Overview
 
-**Artifacts** are used for passing different types of data between Griptape components. All tools return artifacts that are later consumed by tasks and tool memory. 
+**Artifacts** are used for passing different types of data between Griptape components. All tools return artifacts that are later consumed by tasks and task memory. 
 Artifacts make sure framework components enforce contracts when passing and consuming data.
 
 ## TextArtifact
@@ -9,7 +9,7 @@ Used for passing text data of arbitrary size around the framework. It can be use
 It can also be used to generate a text embedding with [generate_embedding()](../../reference/griptape/artifacts/text_artifact.md#griptape.artifacts.text_artifact.TextArtifact.generate_embedding) 
 and access it with [embedding](../../reference/griptape/artifacts/text_artifact.md#griptape.artifacts.text_artifact.TextArtifact.embedding).
 
-[TaskMemory](../../reference/griptape/memory/tool/task_memory.md) automatically stores [TextArtifact](../../reference/griptape/artifacts/text_artifact.md)s returned by tool activities and returns artifact IDs back to the LLM.
+[TaskMemory](../../reference/griptape/memory/task/task_memory.md) automatically stores [TextArtifact](../../reference/griptape/artifacts/text_artifact.md)s returned by tool activities and returns artifact IDs back to the LLM.
 
 ## CsvRowArtifact
 
@@ -18,11 +18,11 @@ Used for passing structured row data around the framework. It inherits from [Tex
 
 ## InfoArtifact
 
-Used for passing short notifications back to the LLM without tool memory storing them.
+Used for passing short notifications back to the LLM without task memory storing them.
 
 ## ErrorArtifact
 
-Used for passing errors back to the LLM without tool memory storing them.
+Used for passing errors back to the LLM without task memory storing them.
 
 ## BlobArtifact
 
@@ -31,4 +31,4 @@ Treat it as a way to return unstructured data, such as images, videos, audio, an
 Each blob has a [name](../../reference/griptape/artifacts/base_artifact.md#griptape.artifacts.base_artifact.BaseArtifact.name) and 
 [dir](../../reference/griptape/artifacts/blob_artifact.md#griptape.artifacts.blob_artifact.BlobArtifact.dir) to uniquely identify stored objects.
 
-[TaskMemory](../../reference/griptape/memory/tool/task_memory.md) automatically stores [BlobArtifact](../../reference/griptape/artifacts/blob_artifact.md)s returned by tool activities that can be reused by other tools.
+[TaskMemory](../../reference/griptape/memory/task/task_memory.md) automatically stores [BlobArtifact](../../reference/griptape/artifacts/blob_artifact.md)s returned by tool activities that can be reused by other tools.

--- a/docs/griptape-framework/tools/task-memory.md
+++ b/docs/griptape-framework/tools/task-memory.md
@@ -5,7 +5,7 @@ Task Memory augments activity inputs and outputs with storage capabilities. It's
 * **Long textual content**: when textual content returned by tools can't fit in the token limit, it's often useful to perform operations on it in a separate process, not in the main LLM.
 * **Non-textual content**: tools can generate images, videos, PDFs, and other non-textual content that can be stored in memory and acted upon later by other tools.
 
-By default, Griptape augments all tool outputs with [TaskMemory](../../reference/griptape/memory/tool/task_memory.md) but you can override at the structure, task, or tool activity level.
+By default, Griptape augments all tool outputs with [TaskMemory](../../reference/griptape/memory/task/task_memory.md) but you can override at the structure, task, or tool activity level.
 
 
 ## Task Memory
@@ -21,7 +21,7 @@ from griptape.engines import VectorQueryEngine, PromptSummaryEngine, CsvExtracti
 from griptape.drivers import LocalVectorStoreDriver, OpenAiEmbeddingDriver
 
 """
-Define tool memory for storing textual and
+Define task memory for storing textual and
 non-textual content.
 """
 task_memory = TaskMemory(

--- a/docs/griptape-tools/official-tools/vector-store-client.md
+++ b/docs/griptape-tools/official-tools/vector-store-client.md
@@ -1,4 +1,4 @@
-The [VectorStoreClient](../../reference/griptape/tools/vector_store_client/tool.md) enables LLMs to dynamically query tool memory.
+The [VectorStoreClient](../../reference/griptape/tools/vector_store_client/tool.md) enables LLMs to dynamically query task memory.
 
 Here is an example of how it can be used with the Pincone storage driver:
 


### PR DESCRIPTION


<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--164.org.readthedocs.build/en/164/

<!-- readthedocs-preview griptape end -->