### PR TITLE
Add note about configuring corresponding prompt drivers and embedding drivers

### DIFF
--- a/docs/griptape-framework/structures/prompt-drivers.md
+++ b/docs/griptape-framework/structures/prompt-drivers.md
@@ -53,8 +53,8 @@ print(result.value)
 
 Griptape offers the following Prompt Drivers for interacting with LLMs.
 
-!!! info
-    When overriding the default Prompt Driver in a Structure (Agent, Pipeline, or Workflow), take care to ensure the configured Embedding Driver is compatible with the Prompt Driver you've selected.
+!!! warning
+    When overriding a default Prompt Driver, take care to ensure the Structure's configured Embedding Driver is compatible with the Prompt Driver you've selected. If Task Memory isn't needed, you can avoid compatability issues by setting `task_memory=None` to disable Task Memory in your Structure.
 
 ### OpenAI Chat
 

--- a/docs/griptape-framework/structures/prompt-drivers.md
+++ b/docs/griptape-framework/structures/prompt-drivers.md
@@ -54,7 +54,7 @@ print(result.value)
 Griptape offers the following Prompt Drivers for interacting with LLMs.
 
 !!! warning
-    When overriding a default Prompt Driver, take care to ensure the Structure's configured Embedding Driver is compatible with the Prompt Driver you've selected. If Task Memory isn't needed, you can avoid compatability issues by setting `task_memory=None` to disable Task Memory in your Structure.
+    When overriding a default Prompt Driver, take care to ensure you've updated the Structure's configured Embedding Driver as well. If Task Memory isn't needed, you can avoid compatability issues by setting `task_memory=None` to disable Task Memory in your Structure.
 
 ### OpenAI Chat
 

--- a/docs/griptape-framework/structures/prompt-drivers.md
+++ b/docs/griptape-framework/structures/prompt-drivers.md
@@ -53,6 +53,9 @@ print(result.value)
 
 Griptape offers the following Prompt Drivers for interacting with LLMs.
 
+!!! info
+    When overriding the default Prompt Driver in a Structure (Agent, Pipeline, or Workflow), take care to ensure the configured Embedding Driver is compatible with the Prompt Driver you've selected.
+
 ### OpenAI Chat
 
 The [OpenAiChatPromptDriver](../../reference/griptape/drivers/prompt/openai_chat_prompt_driver.md) connects to the [OpenAI Chat](https://platform.openai.com/docs/guides/chat) API.


### PR DESCRIPTION
Adds a warning to the Prompt Drivers page indicating that a developer should be careful about selecting corresponding Prompt Driver and Embedding Driver pairs. This should be temporary until a more robust defaults management solution is implemented.

Related to griptape-ai/griptape#471