### PR TITLE
Fix workflow example

### DIFF
--- a/docs/griptape-framework/structures/workflows.md
+++ b/docs/griptape-framework/structures/workflows.md
@@ -46,7 +46,10 @@ workflow.add_task(story_task)
 
 character_task_1 = character_task("scotty", "Scotty")
 character_task_2 = character_task("annie", "Annie")
-workflow.insert_tasks(world_task, [character_task_1, character_task_2], story_task)
+
+# Note the preserve_relationship flag. This ensures that world_task remains a parent of
+# story_task so its output can be referenced in the story_task prompt.
+workflow.insert_tasks(world_task, [character_task_1, character_task_2], story_task, preserve_relationship=True)
 
 workflow.run()
 ```


### PR DESCRIPTION
The workflow story generation example uses insert_tasks but does not set `preserve_relationship=True`. As a result, the output of the `world_task` is not available to `story_task`. This updates the example to set the flag and maintain the relationship so the output is available for `story_task`.

<!-- readthedocs-preview griptape start -->
----
:books: Documentation preview :books:: https://griptape--168.org.readthedocs.build/en/168/

<!-- readthedocs-preview griptape end -->