### PR TITLE
Rename BedrockEmbeddingDriver to AmazonBedrockTitanEmbeddingDriver

### DIFF
--- a/docs/griptape-framework/data/embedding-drivers.md
+++ b/docs/griptape-framework/data/embedding-drivers.md
@@ -37,12 +37,12 @@ with updated defaults.
 !!! info
     This driver requires the `drivers-embedding-amazon-bedrock` [extra](../index.md#extras).
 
-The [BedrockTitanEmbeddingDriver](../../reference/griptape/drivers/embedding/bedrock_titan_embedding_driver.md) uses the [Amazon Bedrock Embeddings API](https://docs.aws.amazon.com/bedrock/latest/userguide/embeddings.html).
+The [AmazonBedrockTitanEmbeddingDriver](../../reference/griptape/drivers/embedding/bedrock_titan_embedding_driver.md) uses the [Amazon Bedrock Embeddings API](https://docs.aws.amazon.com/bedrock/latest/userguide/embeddings.html).
 
 ```python
-from griptape.drivers import BedrockTitanEmbeddingDriver
+from griptape.drivers import AmazonBedrockTitanEmbeddingDriver
 
-embeddings = BedrockTitanEmbeddingDriver().embed_string("Hello world!")
+embeddings = AmazonBedrockTitanEmbeddingDriver().embed_string("Hello world!")
 
 # display the first 3 embeddings
 print(embeddings[:3])


### PR DESCRIPTION
Docs for https://github.com/griptape-ai/griptape/pull/499

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--181.org.readthedocs.build/en/181/

<!-- readthedocs-preview griptape end -->