### PR TITLE
Hack to exclude code snippets from pytest

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -5,3 +5,8 @@
 .md-typeset table:not([class]) {
     display: table;
 }
+
+/* Hide the code block title since we're using it for other purposes.*/
+.filename {
+    display: none !important
+}

--- a/docs/griptape-framework/drivers/embedding-drivers.md
+++ b/docs/griptape-framework/drivers/embedding-drivers.md
@@ -94,7 +94,7 @@ The [AmazonSageMakerEmbeddingDriver](../../reference/griptape/drivers/embedding/
     This driver requires the `drivers-embedding-amazon-sagemaker` [extra](../index.md#extras).
 
 ##### TensorFlow Hub Models
-```python
+```python title="PYTEST_IGNORE"
 import os
 from griptape.drivers import AmazonSageMakerEmbeddingDriver, SageMakerTensorFlowHubEmbeddingModelDriver
 
@@ -110,7 +110,7 @@ print(embeddings[:3])
 ```
 
 ##### HuggingFace Models
-```python
+```python title="PYTEST_IGNORE"
 import os
 from griptape.drivers import AmazonSageMakerEmbeddingDriver, SageMakerHuggingFaceEmbeddingModelDriver
 

--- a/docs/griptape-framework/drivers/prompt-drivers.md
+++ b/docs/griptape-framework/drivers/prompt-drivers.md
@@ -271,7 +271,7 @@ agent.run("Hello Girafatron, what is your favorite animal?")
 
 The [HuggingFaceHubPromptDriver](#hugging-face-hub) also supports [Text Generation Interface](https://huggingface.co/docs/text-generation-inference/basic_tutorials/consuming_tgi#inference-client) for running models locally. To use Text Generation Interface, just set `model` to a TGI endpoint.
 
-```python
+```python title="PYTEST_IGNORE"
 import os
 from griptape.structures import Agent
 from griptape.drivers import HuggingFaceHubPromptDriver

--- a/docs/griptape-tools/custom-tools/index.md
+++ b/docs/griptape-tools/custom-tools/index.md
@@ -1,4 +1,4 @@
-# Custom Tools
+## Overview
 
 Building your own tools is easy with Griptape!
 
@@ -30,7 +30,7 @@ To add Python dependencies for your tool, add a `requirements.txt` file. The too
 
 Next, create a `tool.py` file with the following code:
 
-```python
+```python title="PYTEST_IGNORE"
 import random
 from griptape.artifacts import TextArtifact
 from griptape.tools import BaseTool
@@ -58,7 +58,7 @@ class RandomNumberGenerator(BaseTool):
 
 Finally, let's test our tool:
 
-```python
+```python title="PYTEST_IGNORE"
 from griptape.structures import Agent
 from rng_tool.tool import RandomNumberGenerator
 

--- a/docs/griptape-tools/index.md
+++ b/docs/griptape-tools/index.md
@@ -2,7 +2,7 @@ Tools give the LLM abilities to invoke outside APIs, reference data sets, and ge
 
 Griptape tools are special Python classes that LLMs can use to accomplish specific goals. Here is an example custom tool for generating a random number:
 
-```python
+```python title="PYTEST_IGNORE"
 import random
 from griptape.artifacts import TextArtifact
 from griptape.tools import BaseTool
@@ -30,7 +30,7 @@ A tool can have many "activities" as denoted by the `@activity` decorator. Each 
 
 Output artifacts from all tool activities (except for `InfoArtifact` and `ErrorArtifact`) go to short-term `TaskMemory`. To disable that behavior set the `off_prompt` tool parameter to `False`:
 
-```python
+```python title="PYTEST_IGNORE"
 RandomNumberGenerator(off_prompt=False)
 ```
 

--- a/tests/integration/utils/code_blocks.py
+++ b/tests/integration/utils/code_blocks.py
@@ -28,7 +28,24 @@ def check_code_block(block: str, lang: str = "python") -> str:
     """
     first_line = block.split("\n")[0]
     if lang:
-        if first_line[3:] != lang:
+        line_elements = first_line[3:].split(" ", 2)
+        if len(line_elements) == 1:
+            block_lang = line_elements[0]
+            title_value = None
+        elif len(line_elements) == 2:
+            block_lang, title = line_elements
+            title_elements = title.replace(" ", "").split("=", 2)
+            if len(title_elements) == 2:
+                _, title_value = title_elements
+            else:
+                title_value = None
+        else:
+            block_lang = None
+            title_value = None
+
+        if block_lang != lang:
+            return ""
+        if title_value == '"PYTEST_IGNORE"':
             return ""
     return "\n".join(block.split("\n")[1:])
 


### PR DESCRIPTION
`title` is the only valid text we can put after a code block language and still have it render. Since we're not using this field, we can stick some data in it and hide it with css.

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--216.org.readthedocs.build//216/

<!-- readthedocs-preview griptape end -->