### PR TITLE
Fixes: agent example, poetry commands

### DIFF
--- a/docs/griptape-framework/index.md
+++ b/docs/griptape-framework/index.md
@@ -22,7 +22,7 @@ By default, Griptape uses [OpenAI Completions API](https://platform.openai.com/d
 Install **griptape**:
 
 ```
-pip install griptape[all] -U
+pip install "griptape[all]" -U
 ```
 
 ### Using Poetry
@@ -36,7 +36,7 @@ poetry new griptape-quickstart
 Change your working directory to the new `griptape-quickstart` directory created by Poetry and add the the `griptape` dependency. 
 
 ```
-poetry add griptape[all]
+poetry add "griptape[all]"
 ```
 
 ### Extras
@@ -56,7 +56,7 @@ poetry add griptape
 
 To install specific extras (e.g., drivers for [AnthropicPromptDriver](./drivers/prompt-drivers.md#anthropic) and [PineconeVectorStoreDriver](./drivers/vector-store-drivers.md#pinecone)):
 ```
-poetry add griptape[drivers-prompt-anthropic,drivers-vector-pinecone]
+poetry add "griptape[drivers-prompt-anthropic,drivers-vector-pinecone]"
 ```
 
 For a comprehensive list of extras, please refer to the `[tool.poetry.extras]` section of Griptape's [pyproject.toml](https://github.com/griptape-ai/griptape/blob/main/pyproject.toml).

--- a/docs/griptape-framework/structures/agents.md
+++ b/docs/griptape-framework/structures/agents.md
@@ -16,37 +16,33 @@ from griptape.structures import Agent
 
 agent = Agent(
     input_template="Calculate the following: {{ args[0] }}",
-    tools=[Calculator()]
+    tools=[Calculator(off_prompt=False)]
 )
 
-agent.run("what's 123^312?")
+agent.run("what's 123^5?")
 ```
 
 ```
-[09/08/23 10:11:31] INFO     ToolkitTask 319f53af2e564c15a3b97992fc039ec9
-                             Input: Calculate the following: what's 123^312?
-[09/08/23 10:11:55] INFO     Subtask cbd5bb8684ad4fc59958201efbf14743
-                             Thought: The user wants to calculate the value of 123 raised to the power of 312. I can use the Calculator tool
-                             to perform this calculation.
-
-                             Action: {"name": "Calculator", "path": "calculate", "input": {"values": {"expression":
-                             "123**312"}}}
-                    INFO     Subtask cbd5bb8684ad4fc59958201efbf14743
-                             Response:
-                             11230388208945295722090491952733133124202871121067044284403441616854053130045246777417573635449877716182202751456
-                             62903768337745814236262209544548389555407097435988334710646912635818793342584092805141253230302226219003560706069
-                             42457739968799225811781682901969575983855664495472037997890318771511185547708335412624757899597237206373758262442
-                             72269858013479598852506666010704868797813623903160430655651532132073996589276408598241791795573009265505912300559
-                             47848517605515539611362917584666826953065776743002119105282582194109888263281423789852046556346579319777145449509
-                             5671672325351081760983520684046903739998382099007883142337182654942065184263509761170721
-[09/08/23 10:12:22] INFO     ToolkitTask 319f53af2e564c15a3b97992fc039ec9
-                             Output: The result of 123 raised to the power of 312 is
-                             11230388208945295722090491952733133124202871121067044284403441616854053130045246777417573635449877716182202751456
-                             62903768337745814236262209544548389555407097435988334710646912635818793342584092805141253230302226219003560706069
-                             42457739968799225811781682901969575983855664495472037997890318771511185547708335412624757899597237206373758262442
-                             72269858013479598852506666010704868797813623903160430655651532132073996589276408598241791795573009265505912300559
-                             47848517605515539611362917584666826953065776743002119105282582194109888263281423789852046556346579319777145449509
-                             5671672325351081760983520684046903739998382099007883142337182654942065184263509761170721.
+[03/28/24 09:38:24] INFO     ToolkitTask 1420d56d67084cb5829ea0510f0f0712
+                             Input: Calculate the following: what's 123^5?
+[03/28/24 09:38:29] INFO     Subtask 41d8edfda21a4bf884fc9c0a40a98b2e
+                             Thought: The user wants to calculate the value of 123 raised to the power of 5. I will use the Calculator action to perform this calculation.
+                             Actions: [
+                               {
+                                 "name": "Calculator",
+                                 "path": "calculate",
+                                 "input": {
+                                   "values": {
+                                     "expression": "123**5"
+                                   }
+                                 },
+                                 "output_label": "calculation_result"
+                               }
+                             ]
+                    INFO     Subtask 41d8edfda21a4bf884fc9c0a40a98b2e
+                             Response: calculation_result output: 28153056843
+[03/28/24 09:38:31] INFO     ToolkitTask 1420d56d67084cb5829ea0510f0f0712
+                             Output: The result of 123 raised to the power of 5 is 28153056843.
 ```
 
 ## Prompt Task Agent


### PR DESCRIPTION
Fixes the agent calculator example and wraps poetry commands using square-bracket syntax in quotes.

<!-- readthedocs-preview griptape start -->
----
📚 Documentation preview 📚: https://griptape--240.org.readthedocs.build//240/

<!-- readthedocs-preview griptape end -->