### PR TITLE
Revert "Run integration tests on changed files"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,8 @@
-name: Docs Integration Tests
+name: Integration Tests
 
 on:
   pull_request:
     branches: [ "main", "dev" ]
-
-
 
 jobs:
   test:
@@ -108,19 +106,9 @@ jobs:
       VOYAGE_API_KEY: ${{ secrets.INTEG_VOYAGE_API_KEY }}
 
     steps:
-      - name: Get all changed docs files
-        id: changed-markdown-files
-        uses: tj-actions/changed-files@v43
-        with:
-          files: |
-            docs:
-              - docs/**.md
       - name: Checkout actions
         uses: actions/checkout@v3
       - name: Init environment 
         uses: ./.github/actions/init-environment 
       - name: Run integration tests
-        if: steps.changed-markdown-files.outputs.any_changed == 'true'
-        run: pytest -v ${{ steps.changed-markdown-files.outputs.all_changed_files }}
-        env:
-          DOCS_ALL_CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.docs_all_changed_files }}
+        run: pytest -v tests/integration

--- a/tests/integration/test_code_blocks.py
+++ b/tests/integration/test_code_blocks.py
@@ -4,12 +4,8 @@ import os
 import pytest
 from utils.code_blocks import get_all_code_blocks, check_py_string
 
-docs_all_changed_files = os.environ.get("DOCS_ALL_CHANGED_FILES", "").splitlines()
-
-all_code_blocks = [
-    get_all_code_blocks(changed_file) for changed_file in docs_all_changed_files
-]
-all_code_blocks = [block for sublist in all_code_blocks for block in sublist]
+code_path = os.environ.get("INTEG_CODE_PATH", "**/*.md")
+all_code_blocks = get_all_code_blocks(code_path)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This reverts commit 19badccb3e63f0daff7af5b9ba81a692d6937fca that was an accidental push to `dev`.

This repo is about to be archived from https://github.com/griptape-ai/griptape/pull/744 but I want to leave it in a good state.